### PR TITLE
Disable syslog service on XenServers 6 (CentOS 5-based) too.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -406,7 +406,8 @@ class rsyslog (
 
   ### Disable syslogd service where present by default
   if $::osfamily == 'RedHat'
-  and $::lsbmajdistrelease == '5'
+  and ($::lsbmajdistrelease == '5' or
+  ($::operatingsystem == 'XenServer' and $::lsbmajdistrelease == '6'))
   and ! defined(Service['syslog']) {
     service { 'syslog':
       ensure    => stopped,


### PR DESCRIPTION
Disable syslog service on XenServers 6 (CentOS 5-based but with a lsbmajdistrelease set to 6) too.
