### PR TITLE
Fixed: Resource type not found

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,7 +26,7 @@ class rsyslog::params {
   }
 
   $service = $::operatingsystem ? {
-    OpenSuSE => 'syslog',
+    'OpenSuSE' => 'syslog',
     default  => 'rsyslog',
   }
 


### PR DESCRIPTION
Fixed an issue when using this module with puppet 4.8 (and later).

Server Error: Evaluation Error: Resource type not found: OpenSuSE at ...
